### PR TITLE
Use now.json

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,10 @@
+"now": {
+  "type": "static",
+  "alias": "<your-source-domain>",
+  "static": {
+    "redirects": [{
+      "source": "/*",
+      "destination": "https://<your-destination-domain>"
+    }]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,17 +2,5 @@
   "name": "now-static-redirect",
   "version": "1.0.0",
   "license": "MIT",
-  "author": "Nathaniel Hill <nata@goguna.com>",
-  "now": {
-    "type": "static",
-    "alias": "<your-source-domain>",
-    "static": {
-      "redirects": [
-        {
-          "source": "/*",
-          "destination": "https://<your-destination-domain>"
-        }
-      ]
-    }
-  }
+  "author": "Nathaniel Hill <nata@goguna.com>"
 }


### PR DESCRIPTION
Just move the `now` configuration field inside `package.json` into a standalone `now.json`. Fixes https://github.com/NathanielHill/now-static-redirect/issues/1 for me.